### PR TITLE
Use camera-specific FOV for CMU dataset

### DIFF
--- a/scene/cmu_dataset.py
+++ b/scene/cmu_dataset.py
@@ -1,5 +1,4 @@
 import json
-import math
 import os
 
 import numpy as np
@@ -7,7 +6,7 @@ import torchvision.transforms as T
 from PIL import Image
 from torch.utils.data import Dataset
 
-from scene.dataset_readers import CameraInfo
+from scene.dataset_readers import CameraInfoExtra
 from utils.graphics_utils import focal2fov
 class PanopticDataset(Dataset):
     def __init__(self, datadir: str, json_path: str):
@@ -35,6 +34,10 @@ class PanopticDataset(Dataset):
                 K = np.array(K_list, dtype=np.float32).reshape(3, 3)
                 fx = float(K[0, 0])
                 fy = float(K[1, 1])
+                cx = float(K[0, 2])
+                cy = float(K[1, 2])
+                fovx = focal2fov(fx, self.w)
+                fovy = focal2fov(fy, self.h)
 
                 self.entries.append(
                     {
@@ -42,16 +45,15 @@ class PanopticDataset(Dataset):
                         "K": K,
                         "fx": fx,
                         "fy": fy,
+                        "cx": cx,
+                        "cy": cy,
+                        "FovX": fovx,
+                        "FovY": fovy,
                         "w2c": np.array(w2c_list, dtype=np.float32),
                         "fn": fn,
                         "cam_id": cid,
                     }
                 )
-
-        # compute FOVs from fx, fy
-        # note: focal2fov(pixels, focal) -> radians
-        self.FovX = focal2fov(self.w, np.mean([e["fx"] for e in self.entries]))
-        self.FovY = focal2fov(self.h, np.mean([e["fy"] for e in self.entries]))
 
         # simple PIL→Tensor loader
         self.transform = T.ToTensor()
@@ -71,6 +73,20 @@ class PanopticDataset(Dataset):
         R = np.transpose(w2c[:3, :3])
         T = w2c[:3, 3]
         
-        return CameraInfo(uid=idx, R=R, T=T, FovY=self.FovY, FovX=self.FovX, image=img,
-                                image_path=img_path, image_name=e["fn"], width=self.w, height=self.h,
-                                timestamp = e["time"])
+        return CameraInfoExtra(
+            uid=idx,
+            R=R,
+            T=T,
+            FovY=e["FovY"],
+            FovX=e["FovX"],
+            image=img,
+            image_path=img_path,
+            image_name=e["fn"],
+            width=self.w,
+            height=self.h,
+            timestamp=e["time"],
+            focal_length_x=e["fx"],
+            focal_length_y=e["fy"],
+            cx=e["cx"],
+            cy=e["cy"],
+        )

--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -59,7 +59,8 @@ class CameraInfoExtra(NamedTuple):
     width: int
     height: int
     timestamp: int
-    focal_length: float
+    focal_length_x: float
+    focal_length_y: float
     cx: float
     cy: float
 
@@ -119,7 +120,10 @@ def readColmapCameras(cam_extrinsics, cam_intrinsics, images_folder, suppress=Fa
 
         if intr.model=="SIMPLE_PINHOLE":
             focal_length_x = intr.params[0]
-            FovY = focal2fov(focal_length_x, height)
+            focal_length_y = intr.params[0]
+            cx = intr.params[1]
+            cy = intr.params[2]
+            FovY = focal2fov(focal_length_y, height)
             FovX = focal2fov(focal_length_x, width)
         elif intr.model=="PINHOLE":
             focal_length_x = intr.params[0]
@@ -137,11 +141,12 @@ def readColmapCameras(cam_extrinsics, cam_intrinsics, images_folder, suppress=Fa
         image = image_path
 
         cam_info = CameraInfoExtra(
-            uid=uid, R=R, T=T, 
+            uid=uid, R=R, T=T,
             FovY=FovY, FovX=FovX, image=image,
-            image_path=image_path, image_name=image_name, 
+            image_path=image_path, image_name=image_name,
             width=width, height=height, timestamp=timestamp,
-            focal_length=focal_length_x,
+            focal_length_x=focal_length_x,
+            focal_length_y=focal_length_y,
             cx=cx, cy=cy,
         )
         cam_infos.append(cam_info)


### PR DESCRIPTION
## Summary
- Compute per-camera field of view for CMU Panoptic dataset instead of using dataset-wide averages
- Pass camera-specific FOVs to `CameraInfoExtra` when loading data
- Extend `CameraInfoExtra` to include per-axis focal lengths and principal point offsets

## Testing
- `python -m py_compile scene/cmu_dataset.py scene/dataset_readers.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc0a3ffb00832097560348101b9637